### PR TITLE
fully allow for unprocessed insertion

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ function renderTemplate (template, type, context) {
     case NUNJUCKS: {
       return template.render(context);
     }
+    default: {
+      // If type not specified, assume raw HTML and no templating needed.
+      return template;
+    }
   }
 }
 
@@ -154,7 +158,7 @@ function getCompiler (type) {
     }
     default: {
       // If type not specified, assume raw HTML and no templating needed.
-      return function (str) { return str; }
+      return function (str) { return str; } ;
     }
   }
 }
@@ -178,6 +182,11 @@ function compileNunjucksTemplate (templateStr) {
 
 function injectTemplateLib (type) {
   return new Promise(function (resolve) {
+    if (type === '') {
+      //no lib injection required
+      return resolve();
+    }
+    
     var scriptEl = LIB_LOADED[type];
 
     // Engine loaded.


### PR DESCRIPTION
In case no type is specified, simply insert referenced src. I believe this may have been intended but not fully implemented since this case is not the real purpose of the component. In the end, it may make sense to separate this case out into its own component.