### PR TITLE
Add `html` as type, +docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Local context variables for the template are passed through the element's [datas
 
 ### Usage
 
+### Types
+
+- `text/html`
+- `text/handlebars`
+- `text/jade`
+- `text/mustache`
+- `text/nunjucks`
+
 #### Browser Installation
 
 Install and use by directly including the [browser files](dist):

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var HANDLEBARS = 'handlebars';
 var JADE = 'jade';
 var MUSTACHE = 'mustache';
 var NUNJUCKS = 'nunjucks';
+var HTML = 'html';
 
 var LIB_LOADED = {};
 LIB_LOADED[HANDLEBARS] = !!window.Handlebars;
@@ -111,6 +112,8 @@ function fetchTemplateFromScriptTag (src, type) {
       type = MUSTACHE;
     } else if (scriptType.indexOf('nunjucks') !== -1) {
       type = NUNJUCKS
+    } else if(scriptType.indexOf('html') !== -1) {
+      type = HTML;
     } else {
       error('Template type could not be inferred from the script tag. Please add a type.');
       return;


### PR DESCRIPTION
Fixes use case where script tags should just be HTML and not any specific template engine